### PR TITLE
Fix NodeJS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .cache
 .DS_Store
+/browser/
 /dist/
 /demoout/
 /tsout/
 node_modules/
+.vscode/*

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,4 @@
-const celer = require('../dist/index');
+const celer = require('../browser/browser'); // '../dist/index' for NodeJS
 
 const client = new celer.Client('http://localhost:29979');
 client

--- a/package-lock.json
+++ b/package-lock.json
@@ -829,6 +829,11 @@
         "browser-headers": "^0.4.0"
       }
     },
+    "@improbable-eng/grpc-web-node-http-transport": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.0.2.tgz",
+      "integrity": "sha512-qW2Xw+ExwiAxaTxx7YbGF78p3etVPs1Ca2iN8yj0IiXnkB7K3HAbkrDVlQVsd5eoCZVDN/6G1ak46FW9A2DisQ=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -905,6 +910,11 @@
         "@parcel/utils": "^1.11.0",
         "physical-cpu-count": "^2.0.0"
       }
+    },
+    "@types/detect-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/detect-node/-/detect-node-2.0.0.tgz",
+      "integrity": "sha512-+BozjlbPTACYITf1PWf62HLtDV79HbmZosUN1mv1gGrnjDCRwBXkDKka1sf6YQJvspmfPXVcy+X6tFW62KteeQ=="
     },
     "@types/events": {
       "version": "3.0.0",
@@ -2415,6 +2425,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "diffie-hellman": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "0.8.0",
   "description": "JavaScript library to interact with a local Celer node",
   "scripts": {
-    "clean": "rm -rf dist tsout demoout",
-    "build": "npx tsc -p . && npx parcel build --global celer src/index.ts",
+    "clean": "rm -rf browser dist tsout demoout",
+    "compile": "npx tsc -p .",
+    "bundle:browser": "npx parcel build -d browser --out-file browser.js --global celer src/index.ts",
+    "bundle:node": "npx parcel build --target node src/index.ts",
+    "build": "npm run compile && npm run bundle:browser && npm run bundle:node",
     "doc": "npx typedoc --out doc --excludePrivate src",
     "demo": "npm run build && npx parcel serve -d demoout demo/index.html",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -16,6 +19,7 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
+  "browser": "browser/browser.js",
   "types": "dist/index.d.ts",
   "devDependencies": {
     "parcel-bundler": "^1.11.0",
@@ -24,7 +28,10 @@
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.8.0",
+    "@improbable-eng/grpc-web-node-http-transport": "0.0.2",
+    "@types/detect-node": "^2.0.0",
     "@types/google-protobuf": "^3.2.7",
+    "detect-node": "^2.0.4",
     "google-protobuf": "^3.7.0-rc.2",
     "ts-protoc-gen": "^0.9.0"
   },

--- a/src/webapi/web_api_pb.d.ts
+++ b/src/webapi/web_api_pb.d.ts
@@ -384,7 +384,7 @@ export namespace StateMessage {
   }
 }
 
-export class SendStateMessage extends jspb.Message {
+export class SendStateRequest extends jspb.Message {
   getSessionId(): string;
   setSessionId(value: string): void;
 
@@ -397,16 +397,16 @@ export class SendStateMessage extends jspb.Message {
   setState(value: Uint8Array | string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): SendStateMessage.AsObject;
-  static toObject(includeInstance: boolean, msg: SendStateMessage): SendStateMessage.AsObject;
+  toObject(includeInstance?: boolean): SendStateRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendStateRequest): SendStateRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: SendStateMessage, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): SendStateMessage;
-  static deserializeBinaryFromReader(message: SendStateMessage, reader: jspb.BinaryReader): SendStateMessage;
+  static serializeBinaryToWriter(message: SendStateRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendStateRequest;
+  static deserializeBinaryFromReader(message: SendStateRequest, reader: jspb.BinaryReader): SendStateRequest;
 }
 
-export namespace SendStateMessage {
+export namespace SendStateRequest {
   export type AsObject = {
     sessionId: string,
     destination: string,
@@ -414,7 +414,7 @@ export namespace SendStateMessage {
   }
 }
 
-export class AckStateMessage extends jspb.Message {
+export class AckStateRequest extends jspb.Message {
   getSessionId(): string;
   setSessionId(value: string): void;
 
@@ -422,19 +422,39 @@ export class AckStateMessage extends jspb.Message {
   setSeq(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): AckStateMessage.AsObject;
-  static toObject(includeInstance: boolean, msg: AckStateMessage): AckStateMessage.AsObject;
+  toObject(includeInstance?: boolean): AckStateRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: AckStateRequest): AckStateRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: AckStateMessage, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): AckStateMessage;
-  static deserializeBinaryFromReader(message: AckStateMessage, reader: jspb.BinaryReader): AckStateMessage;
+  static serializeBinaryToWriter(message: AckStateRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AckStateRequest;
+  static deserializeBinaryFromReader(message: AckStateRequest, reader: jspb.BinaryReader): AckStateRequest;
 }
 
-export namespace AckStateMessage {
+export namespace AckStateRequest {
   export type AsObject = {
     sessionId: string,
     seq: string,
+  }
+}
+
+export class ReceiveStatesRequest extends jspb.Message {
+  getSessionId(): string;
+  setSessionId(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ReceiveStatesRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ReceiveStatesRequest): ReceiveStatesRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ReceiveStatesRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ReceiveStatesRequest;
+  static deserializeBinaryFromReader(message: ReceiveStatesRequest, reader: jspb.BinaryReader): ReceiveStatesRequest;
+}
+
+export namespace ReceiveStatesRequest {
+  export type AsObject = {
+    sessionId: string,
   }
 }
 

--- a/src/webapi/web_api_pb.js
+++ b/src/webapi/web_api_pb.js
@@ -12,7 +12,7 @@ var goog = jspb;
 var global = Function('return this')();
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
-goog.exportSymbol('proto.webrpc.AckStateMessage', null, global);
+goog.exportSymbol('proto.webrpc.AckStateRequest', null, global);
 goog.exportSymbol('proto.webrpc.Condition', null, global);
 goog.exportSymbol('proto.webrpc.CreateAppSessionRequest', null, global);
 goog.exportSymbol('proto.webrpc.CreateAppSessionResponse', null, global);
@@ -23,11 +23,12 @@ goog.exportSymbol('proto.webrpc.GetBalanceRequest', null, global);
 goog.exportSymbol('proto.webrpc.GetBalanceResponse', null, global);
 goog.exportSymbol('proto.webrpc.OpenChannelRequest', null, global);
 goog.exportSymbol('proto.webrpc.OpenChannelResponse', null, global);
+goog.exportSymbol('proto.webrpc.ReceiveStatesRequest', null, global);
 goog.exportSymbol('proto.webrpc.RegisterOracleRequest', null, global);
 goog.exportSymbol('proto.webrpc.ResolveOracleRequest', null, global);
 goog.exportSymbol('proto.webrpc.SendConditionalPaymentRequest', null, global);
 goog.exportSymbol('proto.webrpc.SendConditionalPaymentResponse', null, global);
-goog.exportSymbol('proto.webrpc.SendStateMessage', null, global);
+goog.exportSymbol('proto.webrpc.SendStateRequest', null, global);
 goog.exportSymbol('proto.webrpc.SettleAppSessionRequest', null, global);
 goog.exportSymbol('proto.webrpc.SettleAppSessionResponse', null, global);
 goog.exportSymbol('proto.webrpc.StateMessage', null, global);
@@ -2744,12 +2745,12 @@ proto.webrpc.StateMessage.prototype.setState = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.webrpc.SendStateMessage = function(opt_data) {
+proto.webrpc.SendStateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.webrpc.SendStateMessage, jspb.Message);
+goog.inherits(proto.webrpc.SendStateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.webrpc.SendStateMessage.displayName = 'proto.webrpc.SendStateMessage';
+  proto.webrpc.SendStateRequest.displayName = 'proto.webrpc.SendStateRequest';
 }
 
 
@@ -2764,8 +2765,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.webrpc.SendStateMessage.prototype.toObject = function(opt_includeInstance) {
-  return proto.webrpc.SendStateMessage.toObject(opt_includeInstance, this);
+proto.webrpc.SendStateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.webrpc.SendStateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -2774,11 +2775,11 @@ proto.webrpc.SendStateMessage.prototype.toObject = function(opt_includeInstance)
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.webrpc.SendStateMessage} msg The msg instance to transform.
+ * @param {!proto.webrpc.SendStateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.webrpc.SendStateMessage.toObject = function(includeInstance, msg) {
+proto.webrpc.SendStateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     sessionId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     destination: jspb.Message.getFieldWithDefault(msg, 2, ""),
@@ -2796,23 +2797,23 @@ proto.webrpc.SendStateMessage.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.webrpc.SendStateMessage}
+ * @return {!proto.webrpc.SendStateRequest}
  */
-proto.webrpc.SendStateMessage.deserializeBinary = function(bytes) {
+proto.webrpc.SendStateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.webrpc.SendStateMessage;
-  return proto.webrpc.SendStateMessage.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.webrpc.SendStateRequest;
+  return proto.webrpc.SendStateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.webrpc.SendStateMessage} msg The message object to deserialize into.
+ * @param {!proto.webrpc.SendStateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.webrpc.SendStateMessage}
+ * @return {!proto.webrpc.SendStateRequest}
  */
-proto.webrpc.SendStateMessage.deserializeBinaryFromReader = function(msg, reader) {
+proto.webrpc.SendStateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -2844,9 +2845,9 @@ proto.webrpc.SendStateMessage.deserializeBinaryFromReader = function(msg, reader
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.webrpc.SendStateMessage.prototype.serializeBinary = function() {
+proto.webrpc.SendStateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.webrpc.SendStateMessage.serializeBinaryToWriter(this, writer);
+  proto.webrpc.SendStateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -2854,11 +2855,11 @@ proto.webrpc.SendStateMessage.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.webrpc.SendStateMessage} message
+ * @param {!proto.webrpc.SendStateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.webrpc.SendStateMessage.serializeBinaryToWriter = function(message, writer) {
+proto.webrpc.SendStateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getSessionId();
   if (f.length > 0) {
@@ -2888,13 +2889,13 @@ proto.webrpc.SendStateMessage.serializeBinaryToWriter = function(message, writer
  * optional string session_id = 1;
  * @return {string}
  */
-proto.webrpc.SendStateMessage.prototype.getSessionId = function() {
+proto.webrpc.SendStateRequest.prototype.getSessionId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.webrpc.SendStateMessage.prototype.setSessionId = function(value) {
+proto.webrpc.SendStateRequest.prototype.setSessionId = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
@@ -2903,13 +2904,13 @@ proto.webrpc.SendStateMessage.prototype.setSessionId = function(value) {
  * optional string destination = 2;
  * @return {string}
  */
-proto.webrpc.SendStateMessage.prototype.getDestination = function() {
+proto.webrpc.SendStateRequest.prototype.getDestination = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.webrpc.SendStateMessage.prototype.setDestination = function(value) {
+proto.webrpc.SendStateRequest.prototype.setDestination = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
 };
 
@@ -2918,7 +2919,7 @@ proto.webrpc.SendStateMessage.prototype.setDestination = function(value) {
  * optional bytes state = 3;
  * @return {!(string|Uint8Array)}
  */
-proto.webrpc.SendStateMessage.prototype.getState = function() {
+proto.webrpc.SendStateRequest.prototype.getState = function() {
   return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
 };
 
@@ -2928,7 +2929,7 @@ proto.webrpc.SendStateMessage.prototype.getState = function() {
  * This is a type-conversion wrapper around `getState()`
  * @return {string}
  */
-proto.webrpc.SendStateMessage.prototype.getState_asB64 = function() {
+proto.webrpc.SendStateRequest.prototype.getState_asB64 = function() {
   return /** @type {string} */ (jspb.Message.bytesAsB64(
       this.getState()));
 };
@@ -2941,14 +2942,14 @@ proto.webrpc.SendStateMessage.prototype.getState_asB64 = function() {
  * This is a type-conversion wrapper around `getState()`
  * @return {!Uint8Array}
  */
-proto.webrpc.SendStateMessage.prototype.getState_asU8 = function() {
+proto.webrpc.SendStateRequest.prototype.getState_asU8 = function() {
   return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
       this.getState()));
 };
 
 
 /** @param {!(string|Uint8Array)} value */
-proto.webrpc.SendStateMessage.prototype.setState = function(value) {
+proto.webrpc.SendStateRequest.prototype.setState = function(value) {
   jspb.Message.setProto3BytesField(this, 3, value);
 };
 
@@ -2964,12 +2965,12 @@ proto.webrpc.SendStateMessage.prototype.setState = function(value) {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.webrpc.AckStateMessage = function(opt_data) {
+proto.webrpc.AckStateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.webrpc.AckStateMessage, jspb.Message);
+goog.inherits(proto.webrpc.AckStateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.webrpc.AckStateMessage.displayName = 'proto.webrpc.AckStateMessage';
+  proto.webrpc.AckStateRequest.displayName = 'proto.webrpc.AckStateRequest';
 }
 
 
@@ -2984,8 +2985,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.webrpc.AckStateMessage.prototype.toObject = function(opt_includeInstance) {
-  return proto.webrpc.AckStateMessage.toObject(opt_includeInstance, this);
+proto.webrpc.AckStateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.webrpc.AckStateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -2994,11 +2995,11 @@ proto.webrpc.AckStateMessage.prototype.toObject = function(opt_includeInstance) 
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.webrpc.AckStateMessage} msg The msg instance to transform.
+ * @param {!proto.webrpc.AckStateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.webrpc.AckStateMessage.toObject = function(includeInstance, msg) {
+proto.webrpc.AckStateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     sessionId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     seq: jspb.Message.getFieldWithDefault(msg, 2, "")
@@ -3015,23 +3016,23 @@ proto.webrpc.AckStateMessage.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.webrpc.AckStateMessage}
+ * @return {!proto.webrpc.AckStateRequest}
  */
-proto.webrpc.AckStateMessage.deserializeBinary = function(bytes) {
+proto.webrpc.AckStateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.webrpc.AckStateMessage;
-  return proto.webrpc.AckStateMessage.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.webrpc.AckStateRequest;
+  return proto.webrpc.AckStateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.webrpc.AckStateMessage} msg The message object to deserialize into.
+ * @param {!proto.webrpc.AckStateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.webrpc.AckStateMessage}
+ * @return {!proto.webrpc.AckStateRequest}
  */
-proto.webrpc.AckStateMessage.deserializeBinaryFromReader = function(msg, reader) {
+proto.webrpc.AckStateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -3059,9 +3060,9 @@ proto.webrpc.AckStateMessage.deserializeBinaryFromReader = function(msg, reader)
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.webrpc.AckStateMessage.prototype.serializeBinary = function() {
+proto.webrpc.AckStateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.webrpc.AckStateMessage.serializeBinaryToWriter(this, writer);
+  proto.webrpc.AckStateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -3069,11 +3070,11 @@ proto.webrpc.AckStateMessage.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.webrpc.AckStateMessage} message
+ * @param {!proto.webrpc.AckStateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.webrpc.AckStateMessage.serializeBinaryToWriter = function(message, writer) {
+proto.webrpc.AckStateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getSessionId();
   if (f.length > 0) {
@@ -3096,13 +3097,13 @@ proto.webrpc.AckStateMessage.serializeBinaryToWriter = function(message, writer)
  * optional string session_id = 1;
  * @return {string}
  */
-proto.webrpc.AckStateMessage.prototype.getSessionId = function() {
+proto.webrpc.AckStateRequest.prototype.getSessionId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.webrpc.AckStateMessage.prototype.setSessionId = function(value) {
+proto.webrpc.AckStateRequest.prototype.setSessionId = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
@@ -3111,14 +3112,156 @@ proto.webrpc.AckStateMessage.prototype.setSessionId = function(value) {
  * optional string seq = 2;
  * @return {string}
  */
-proto.webrpc.AckStateMessage.prototype.getSeq = function() {
+proto.webrpc.AckStateRequest.prototype.getSeq = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.webrpc.AckStateMessage.prototype.setSeq = function(value) {
+proto.webrpc.AckStateRequest.prototype.setSeq = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.webrpc.ReceiveStatesRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.webrpc.ReceiveStatesRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.webrpc.ReceiveStatesRequest.displayName = 'proto.webrpc.ReceiveStatesRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.webrpc.ReceiveStatesRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.webrpc.ReceiveStatesRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.webrpc.ReceiveStatesRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.webrpc.ReceiveStatesRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    sessionId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.webrpc.ReceiveStatesRequest}
+ */
+proto.webrpc.ReceiveStatesRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.webrpc.ReceiveStatesRequest;
+  return proto.webrpc.ReceiveStatesRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.webrpc.ReceiveStatesRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.webrpc.ReceiveStatesRequest}
+ */
+proto.webrpc.ReceiveStatesRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setSessionId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.webrpc.ReceiveStatesRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.webrpc.ReceiveStatesRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.webrpc.ReceiveStatesRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.webrpc.ReceiveStatesRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getSessionId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string session_id = 1;
+ * @return {string}
+ */
+proto.webrpc.ReceiveStatesRequest.prototype.getSessionId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.webrpc.ReceiveStatesRequest.prototype.setSessionId = function(value) {
+  jspb.Message.setProto3StringField(this, 1, value);
 };
 
 

--- a/src/webapi/web_api_pb_service.d.ts
+++ b/src/webapi/web_api_pb_service.d.ts
@@ -62,18 +62,27 @@ type WebApiCreateAppSession = {
 type WebApiReceiveStates = {
   readonly methodName: string;
   readonly service: typeof WebApi;
-  readonly requestStream: true;
+  readonly requestStream: false;
   readonly responseStream: true;
-  readonly requestType: typeof web_api_pb.AckStateMessage;
+  readonly requestType: typeof web_api_pb.ReceiveStatesRequest;
   readonly responseType: typeof web_api_pb.StateMessage;
 };
 
-type WebApiSendStates = {
+type WebApiSendState = {
   readonly methodName: string;
   readonly service: typeof WebApi;
-  readonly requestStream: true;
+  readonly requestStream: false;
   readonly responseStream: false;
-  readonly requestType: typeof web_api_pb.SendStateMessage;
+  readonly requestType: typeof web_api_pb.SendStateRequest;
+  readonly responseType: typeof google_protobuf_empty_pb.Empty;
+};
+
+type WebApiAckState = {
+  readonly methodName: string;
+  readonly service: typeof WebApi;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof web_api_pb.AckStateRequest;
   readonly responseType: typeof google_protobuf_empty_pb.Empty;
 };
 
@@ -122,7 +131,8 @@ export class WebApi {
   static readonly SendConditionalPayment: WebApiSendConditionalPayment;
   static readonly CreateAppSession: WebApiCreateAppSession;
   static readonly ReceiveStates: WebApiReceiveStates;
-  static readonly SendStates: WebApiSendStates;
+  static readonly SendState: WebApiSendState;
+  static readonly AckState: WebApiAckState;
   static readonly SettleAppSession: WebApiSettleAppSession;
   static readonly EndAppSession: WebApiEndAppSession;
   static readonly RegisterOracle: WebApiRegisterOracle;
@@ -215,8 +225,25 @@ export class WebApiClient {
     requestMessage: web_api_pb.CreateAppSessionRequest,
     callback: (error: ServiceError|null, responseMessage: web_api_pb.CreateAppSessionResponse|null) => void
   ): UnaryResponse;
-  receiveStates(metadata?: grpc.Metadata): BidirectionalStream<web_api_pb.AckStateMessage, web_api_pb.StateMessage>;
-  sendStates(metadata?: grpc.Metadata): RequestStream<web_api_pb.SendStateMessage>;
+  receiveStates(requestMessage: web_api_pb.ReceiveStatesRequest, metadata?: grpc.Metadata): ResponseStream<web_api_pb.StateMessage>;
+  sendState(
+    requestMessage: web_api_pb.SendStateRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
+  sendState(
+    requestMessage: web_api_pb.SendStateRequest,
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
+  ackState(
+    requestMessage: web_api_pb.AckStateRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
+  ackState(
+    requestMessage: web_api_pb.AckStateRequest,
+    callback: (error: ServiceError|null, responseMessage: google_protobuf_empty_pb.Empty|null) => void
+  ): UnaryResponse;
   settleAppSession(
     requestMessage: web_api_pb.SettleAppSessionRequest,
     metadata: grpc.Metadata,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "declaration": true,
     "declarationDir": "dist",
     "outDir": "tsout",


### PR DESCRIPTION
The WebSocketTransport in grpc-web uses a global WebSocket object which
does not exist by default in the NodeJS environment.

The fix in the API server is to remove bidi-streaming from the gRPC and
using only HTTP/2 instead. The fix in the JS client is to detect NodeJS
and use NodeHttpTransport.

Modify package.json to support bundling for browser and NodeJS
respectively.